### PR TITLE
Move kbn-loading-indicator to element

### DIFF
--- a/src/ui/public/chrome/__tests__/kbn_loading_indicator.js
+++ b/src/ui/public/chrome/__tests__/kbn_loading_indicator.js
@@ -16,7 +16,7 @@ describe('kbnLoadingIndicator', function () {
         $rootScope.chrome = {
           httpActive: (hasActiveConnections ? [1] : [])
         };
-        const $el = $('<div kbn-loading-indicator><div id="other-content"></div></div>');
+        const $el = $('<kbn-loading-indicator></kbn-loading-indicator>');
         $rootScope.$apply();
         $compile($el)($rootScope);
         return $el;
@@ -38,10 +38,4 @@ describe('kbnLoadingIndicator', function () {
     const $el  = compile(true);
     expect($el.find('.spinner.ng-hide')).to.have.length(0);
   });
-
-  it('doesn\'t modify the contents of what the elment already has', function () {
-    const $el = compile();
-    expect($el.find('#other-content')).to.have.length(1);
-  });
-
 });

--- a/src/ui/public/chrome/chrome.html
+++ b/src/ui/public/chrome/chrome.html
@@ -64,7 +64,8 @@
         </div>
         <!-- /Full navbar -->
       </nav>
-      <div class="application" ng-class="'tab-' + chrome.getFirstPathSegment() + ' ' + chrome.getApplicationClasses()" ng-view kbn-loading-indicator></div>
+      <kbn-loading-indicator></kbn-loading-indicator>
+      <div class="application" ng-class="'tab-' + chrome.getFirstPathSegment() + ' ' + chrome.getApplicationClasses()" ng-view></div>
     </div>
   </div>
 </div>

--- a/src/ui/public/chrome/directives/kbn_loading_indicator.js
+++ b/src/ui/public/chrome/directives/kbn_loading_indicator.js
@@ -7,11 +7,7 @@ UiModules
 .get('ui/kibana')
 .directive('kbnLoadingIndicator', function ($compile) {
   return {
-    restrict: 'AC',
-    link: function (scope, $el) {
-      const $loadingEl = angular.element(spinnerTemplate);
-      $el.append($loadingEl);
-      $compile($loadingEl)(scope);
-    }
+    restrict: 'E',
+    template: spinnerTemplate,
   };
 });


### PR DESCRIPTION
This moves `kbn-loading-indicator` out of the application element and removes the need for a link function.
